### PR TITLE
Set new Docker Repo Registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -153,7 +153,8 @@ jobs:
     steps:
       - id: check_secret_job
         run: |
-          if [[ "${{ secrets.DOCKER_HUB_REPO_NAME }}" != "" && \
+          if [[ "${{ vars.DOCKER_REGISTRY }}" != "" && \
+                "${{ vars.DOCKER_REPO }}" != "" && \
                 "${{ secrets.DOCKER_USERNAME }}" != "" && \
                 "${{ secrets.DOCKER_TOKEN }}" != "" ]]; \
           then
@@ -187,6 +188,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           # CONFIGURE DOCKER SECRETS INTO REPOSITORY
+          registry: ${{ vars.DOCKER_REGISTRY }}
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
@@ -197,8 +199,8 @@ jobs:
           file: docker/alpine.Dockerfile
           push: true
           tags: |
-            ${{ secrets.DOCKER_HUB_REPO_NAME }}:alpine-${{ github.event.release.tag_name }}
-            ${{ secrets.DOCKER_HUB_REPO_NAME }}:alpine
+            ${{ vars.DOCKER_REGISTRY }}/${{ vars.DOCKER_REPO }}:alpine-${{ github.event.release.tag_name }}
+            ${{ vars.DOCKER_REGISTRY }}/${{ vars.DOCKER_REPO }}:alpine
 
   # TODO: Download .tar and add docker image without uncompress
   # Publish docker multiplatform image in Docker Hub Registry to application
@@ -229,6 +231,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           # CONFIGURE DOCKER SECRETS INTO REPOSITORY
+          registry: ${{ vars.DOCKER_REGISTRY }}
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
@@ -240,8 +243,8 @@ jobs:
           platforms: linux/amd64,linux/amd64/v2,linux/arm64/v8
           push: true
           tags: |
-            ${{ secrets.DOCKER_HUB_REPO_NAME }}:${{ github.event.release.tag_name }}
-            ${{ secrets.DOCKER_HUB_REPO_NAME }}:latest
+            ${{ vars.DOCKER_REGISTRY }}/${{ vars.DOCKER_REPO }}:${{ github.event.release.tag_name }}
+            ${{ vars.DOCKER_REGISTRY }}/${{ vars.DOCKER_REPO }}:latest
 
 
 
@@ -256,7 +259,8 @@ jobs:
     steps:
       - id: check_secret_job
         run: |
-          if [[ "${{ secrets.DOCKER_HUB_PROXY_REPO_NAME }}" != "" && \
+          if [[ "${{ vars.DOCKER_REGISTRY }}" != "" && \
+                "${{ vars.DOCKER_REPO_PROXY }}" != "" && \
                 "${{ secrets.DOCKER_USERNAME }}" != "" && \
                 "${{ secrets.DOCKER_TOKEN }}" != "" ]]; \
           then
@@ -296,6 +300,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           # CONFIGURE DOCKER SECRETS INTO REPOSITORY
+          registry: ${{ vars.DOCKER_REGISTRY }}
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
@@ -307,5 +312,5 @@ jobs:
           platforms: linux/amd64,linux/amd64/v2,linux/arm64/v8
           push: true
           tags: |
-            ${{ secrets.DOCKER_HUB_PROXY_REPO_NAME }}:${{ github.event.release.tag_name }}
-            ${{ secrets.DOCKER_HUB_PROXY_REPO_NAME }}:latest
+            ${{ vars.DOCKER_REGISTRY }}/${{ vars.DOCKER_REPO_PROXY }}:${{ github.event.release.tag_name }}
+            ${{ vars.DOCKER_REGISTRY }}/${{ vars.DOCKER_REPO_PROXY }}:latest


### PR DESCRIPTION
https://github.com/solop-develop/adempiere-solop/issues/98

https://github.com/solop-develop/adempiere-report-engine-service/actions/runs/12796078592
Release generado ok adempiere-solop-98-docker-image.0.0.1

Imagen para descargar desde Registry `registry.digitalocean.com/spuy/adempiere-report-engine-service:alpine-adempiere-solop-98-docker-image.0.0.1`