### PR TITLE
fix: Sync session/JWT hardening patches with adempiere-grpc-server

### DIFF
--- a/src/patches/java/org/spin/service/grpc/authentication/SessionManager.java
+++ b/src/patches/java/org/spin/service/grpc/authentication/SessionManager.java
@@ -426,12 +426,7 @@ public class SessionManager {
 	public static String createSessionAndGetToken(String clientVersion, String language, int roleId, int userId, int organizationId, int warehouseId, boolean isOpenID) {
 		MSession session = createSession(clientVersion, language, roleId, userId, organizationId, warehouseId);
 
-		String bearerToken = null;
-		if (isOpenID) {
-			bearerToken = getOpenIDToken(session);
-		} else {
-			bearerToken = createAndGetBearerToken(session, warehouseId, Env.getAD_Language(session.getCtx()));
-		}
+		String bearerToken = createTokenFromSession(session, isOpenID);
 
 		// Update session preferences
 		PreferenceUtil.saveSessionPreferences(
@@ -444,6 +439,29 @@ public class SessionManager {
 		);
 
 		return bearerToken;
+	}
+
+	/**
+	 * Issue a bearer token for an already-existing {@link MSession}. Useful for
+	 * callers that need to control session creation separately from token
+	 * issuance (e.g. change-role / change-organization flows that hold the
+	 * MSession reference before minting the JWT).
+	 *
+	 * @param session  the persisted session
+	 * @param isOpenID if {@code true}, returns the persisted OpenID access
+	 *                 token; otherwise issues a fresh HMAC-signed JWT
+	 * @return the bearer token string
+	 */
+	public static String createTokenFromSession(MSession session, boolean isOpenID) {
+		if (session == null || session.getAD_Session_ID() <= 0) {
+			throw new AdempiereException("@AD_Session_ID@ @NotFound@");
+		}
+		if (isOpenID) {
+			return getOpenIDToken(session);
+		}
+		int warehouseId = Env.getContextAsInt(session.getCtx(), "#M_Warehouse_ID");
+		String language = Env.getAD_Language(session.getCtx());
+		return createAndGetBearerToken(session, warehouseId, language);
 	}
 
 


### PR DESCRIPTION
The report engine runs in its own JVM but shares the database and the Keycloak flow with `adempiere-grpc-server`. Without these patches, a change-role or logout performed by the main backend leaves the report engine serving the previous role/session until its in-memory cache expires — reports run with the wrong tenant filter and return empty.

This PR brings the `src/patches/java/` overlay in sync with the version maintained in `adempiere-grpc-server`. No changes to `src/main/java/`.

## `patches/org/compiere/model`

- **`MSession.afterSave`** — refresh the local `s_sessions` cache on every successful save so callers in this JVM see the row's actual state (including `Processed`) without an extra DB hit. Removes the redundant explicit `s_sessions.remove(...)` from `logout()`.
- **`MRole.removeFromCache(int roleId, int userId)`** — new static helper to evict a `(role, user)` cache entry, enabling the Keycloak resolver to rebuild access SQL with the current tenant context.

## `patches/org/spin/service/grpc/authentication`

- **`SessionManager`** (JWT path):
    - HMAC signing key bound to the current database via `HmacSHA256(configuredSecret, dbName)` — JWTs from another installation no longer validate here even if the configured secret happens to match.
    - New `tenant_id` claim (SHA-256 of the DB fingerprint); mismatch is rejected before any DB lookup.
    - After loading `AD_Session`, cross-validate `JWT.AD_User_ID == session.getCreatedBy()` and `JWT.AD_Client_ID == session.getAD_Client_ID()`; reject on mismatch.
    - Reject JWTs whose `AD_Session` is already `Processed='Y'`.
    - New public `createTokenFromSession(MSession, boolean)` helper.
- **`KeycloakSessionHandler`**:
    - Refuse to reuse an `AD_Session` whose `WebSession` does not start with `"keycloak:"`.
    - Force-reload `MRole` (`removeFromCache` + `get(..., reload=true)`) when resolving an existing session.

## Test

- After a change-role in `adempiere-grpc-server`, hit a report endpoint on this service with the new JWT → SQL filter must reflect the new role's `AD_Client_ID` / `AD_Org_ID`, not the previous one.
- Replay a JWT after server-side logout → rejected with `@Invalid@ @AD_Session_ID@`.
- JWT issued against a different database presented here → rejected.

### Additional context
fixes https://github.com/solop-develop/adempiere-solop/issues/2389