### PR TITLE
fix: Make per-database JWT signing opt-in via ECA52_JWT_BIND_TO_DATABASE flag

### DIFF
--- a/src/patches/java/org/spin/service/grpc/authentication/SessionManager.java
+++ b/src/patches/java/org/spin/service/grpc/authentication/SessionManager.java
@@ -287,12 +287,19 @@ public class SessionManager {
 				.build()
 			;
 			Jws<Claims> claims = parser.parseSignedClaims(tokenValue);
-			// Reject tokens issued for a different tenant/installation.
+			// Opportunistic validation: if the token carries a tenant_id claim
+			// (issued by a build with ECA52_JWT_BIND_TO_DATABASE=Y), require it
+			// to match this installation's tenant. Tokens without the claim
+			// (pre-2026-05-14 builds) are allowed through — the rest of the
+			// flow still cross-validates the JWT user/client against the
+			// AD_Session row loaded from DB.
 			String tokenTenantId = claims.getPayload().get(CLAIM_TENANT_ID, String.class);
-			String currentTenantId = getTenantId();
-			if (tokenTenantId == null || !tokenTenantId.equals(currentTenantId)) {
-				log.warning("JWT tenant_id mismatch");
-				throw new AdempiereException("@Invalid@ @AD_Session_ID@");
+			if (tokenTenantId != null) {
+				String currentTenantId = getTenantId();
+				if (!tokenTenantId.equals(currentTenantId)) {
+					log.warning("JWT tenant_id mismatch");
+					throw new AdempiereException("@Invalid@ @AD_Session_ID@");
+				}
 			}
 			sessionId = NumberManager.getIntFromString(
 				claims.getPayload().getId()
@@ -544,10 +551,41 @@ public class SessionManager {
 		}
 		return secretKey;
 	}
+	/**
+	 * Optional flag that gates the per-database HMAC derivation and the
+	 * {@code tenant_id} claim emission/validation. Disabled by default for
+	 * backward compatibility with services running pre-2026-05-14 builds.
+	 * <p>
+	 * Operators flip it to {@code Y} in {@code AD_SysConfig} (or via
+	 * {@code Ini}) once every service connected to the database has been
+	 * upgraded. Existing JWTs in circulation become invalid at that point.
+	 */
+	private static boolean isDatabaseBindingEnabled() {
+		String value = null;
+		try {
+			value = MSysConfig.getValue(
+				"ECA52_JWT_BIND_TO_DATABASE",
+				Env.getAD_Client_ID(Env.getCtx())
+			);
+		} catch (Exception ignored) {
+			// Context not initialized — fall back to Ini.
+		}
+		if (Util.isEmpty(value, true)) {
+			value = Ini.getProperty("ECA52_JWT_BIND_TO_DATABASE");
+		}
+		return "Y".equalsIgnoreCase(value) || "true".equalsIgnoreCase(value);
+	}
+
 	private static SecretKey getJWT_SecretKey() {
 		byte[] baseKeyBytes = Base64.getDecoder().decode(
 			getJWT_SecretKeyAsString()
 		);
+		if (!isDatabaseBindingEnabled()) {
+			// Backward-compatible mode: sign and verify with the configured
+			// secret directly, like pre-2026-05-14 builds. JWTs interoperate
+			// with any service that has not yet flipped the flag.
+			return Keys.hmacShaKeyFor(baseKeyBytes);
+		}
 		byte[] fingerprintBytes = getDatabaseFingerprint().getBytes(StandardCharsets.UTF_8);
 		try {
 			// Bind the signing key to the current database so tokens signed against
@@ -660,7 +698,14 @@ public class SessionManager {
 			.claim("AD_User_ID", session.getCreatedBy())
 			.claim("M_Warehouse_ID", warehouseId)
 			.claim("AD_Language", language)
-			.claim(CLAIM_TENANT_ID, getTenantId())
+		;
+		// Only stamp the opaque tenant identifier when the operator has opted
+		// into per-database binding; older services would reject the token
+		// otherwise because their signing key still uses the raw secret.
+		if (isDatabaseBindingEnabled()) {
+			jwtBuilder.claim(CLAIM_TENANT_ID, getTenantId());
+		}
+		jwtBuilder
 			.issuedAt(
 				new Date()
 			)


### PR DESCRIPTION


The 2026-05-14 JWT cross-database fixes (HMAC key derived from the DB name + `tenant_id` claim) are not interoperable with older builds: a token signed by an upgraded service is rejected by any service still on the previous version, and vice versa. Production deployments with several services that upgrade on different schedules (e.g. Sabana on one cadence, `adempiere-grpc-server` and `adempiere-report-engine-service` on others) currently break the moment one of them upgrades.

This PR gates the breaking parts behind a single shared flag so operators can deploy the new code everywhere first and flip the protection on atomically.

## Changes (`SessionManager`)

- New helper `isDatabaseBindingEnabled()`. Reads `ECA52_JWT_BIND_TO_DATABASE` from `AD_SysConfig` (per-client → falls back to System), with a final fallback to `Ini.getProperty`. Default: **disabled**.
- `getJWT_SecretKey()`: when the flag is off, signs and verifies with the configured secret directly (pre-2026-05-14 behaviour). When on, derives the HMAC key from `(secret, getDatabaseFingerprint())`.
- `createAndGetBearerToken`: emits the `tenant_id` claim only when the flag is on; older services would reject the token otherwise because their signing key still uses the raw secret.
- `getSessionFromToken`: tenant-id check is now **opportunistic** — a token that carries the claim is required to match the current installation; tokens without the claim are allowed through. Lets a newly-deployed service validate JWTs issued by older peers during rollout.

The two defences that do not break compatibility are untouched:

- Fix N 2 — cross-validation of `JWT.AD_User_ID` / `JWT.AD_Client_ID` against the `AD_Session` row loaded from DB — remains **always on**. It already blocked the original cross-database session-reuse exploit without needing the derived key.
- Fix N 2b — rejection of JWTs whose `AD_Session` is already `Processed='Y'` — remains **always on**.

## Migration

1. Deploy this build to every service connected to the database, with the flag still **off** (default). Behaviour matches the pre-2026-05-14 code; existing tokens keep working.
2. Verify every service is on the new build.
3. Insert one row in the shared database: ```sql INSERT INTO AD_SysConfig (AD_SysConfig_ID, Name, Value, AD_Client_ID, AD_Org_ID, IsActive, ...) VALUES (..., 'ECA52_JWT_BIND_TO_DATABASE', 'Y', 0, 0, 'Y', ...); ```
4. From the next sign onwards, JWTs include the `tenant_id` claim and are signed with the derived key. Tokens issued before the flip become invalid — users re-login once.

## Test

- Flag off, all services on the new build: existing JWT issued before this deploy still validates everywhere. New JWTs do not carry `tenant_id`.
- Flag off, one service on the new build and one on the old build: tokens move between them transparently.
- Flag on: new JWTs carry `tenant_id`. Same JWT presented to a service whose tenant resolver disagrees → rejected with `@Invalid@ @AD_Session_ID@`. JWTs issued before the flip → rejected (expected).

### Additional context
fixes https://github.com/solop-develop/adempiere-solop/issues/2389

