### PR TITLE
fix: Serialize concurrent Keycloak session creation per sid

### DIFF
--- a/src/patches/java/org/spin/service/grpc/authentication/KeycloakSessionHandler.java
+++ b/src/patches/java/org/spin/service/grpc/authentication/KeycloakSessionHandler.java
@@ -17,6 +17,8 @@ import java.sql.Timestamp;
 import java.util.Base64;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Resolves an ADempiere session from a pre-validated Keycloak JWT.
@@ -42,6 +44,15 @@ public class KeycloakSessionHandler {
 		new CCache<>("KeycloakSidMapping", 100, 60); // 60 min timeout
 
 	/**
+	 * Per-sid lock used to serialize the slow path (DB-fallback + create) so that
+	 * two concurrent requests for the same Keycloak sid do not both miss cache,
+	 * both miss DB, and each insert a brand-new AD_Session with the same
+	 * {@code WebSession="keycloak:<sid>"}. Entries are kept for the lifetime of
+	 * the JVM — the per-sid memory footprint is negligible.
+	 */
+	private static final ConcurrentMap<String, Object> sidLocks = new ConcurrentHashMap<>();
+
+	/**
 	 * Resolves an ADempiere session context from a Keycloak JWT.
 	 * <p>
 	 * 1. Decode JWT payload (Base64, no signature validation)
@@ -63,7 +74,7 @@ public class KeycloakSessionHandler {
 			throw new AdempiereException("Keycloak JWT missing 'sid' claim");
 		}
 
-		// 1. Fast path: in-memory cache
+		// 1. Fast path: in-memory cache (no lock — cache reads are thread-safe).
 		Integer existingSessionId = keycloakSessionCache.get(claims.sessionId);
 		if (existingSessionId != null && existingSessionId > 0) {
 			Properties context = loadExistingSessionContext(existingSessionId);
@@ -75,20 +86,41 @@ public class KeycloakSessionHandler {
 			keycloakSessionCache.remove(claims.sessionId);
 		}
 
-		// 2. DB fallback: recover session after restart or cache eviction
-		int dbSessionId = findSessionIdByKeycloakSid(claims.sessionId);
-		if (dbSessionId > 0) {
-			Properties context = loadExistingSessionContext(dbSessionId);
-			if (context != null) {
-				keycloakSessionCache.put(claims.sessionId, dbSessionId); // re-warm cache
-				log.fine("Recovered ADempiere session " + dbSessionId
-					+ " from DB for Keycloak sid: " + claims.sessionId);
-				return context;
+		// Slow path: serialize per-sid so two concurrent requests that both
+		// miss the cache do not both reach createNewSessionContext and produce
+		// duplicate AD_Session rows for the same Keycloak sid.
+		Object lock = sidLocks.computeIfAbsent(claims.sessionId, k -> new Object());
+		synchronized (lock) {
+			// Re-check the cache: a parallel thread that won the race may have
+			// already populated it while we waited.
+			Integer cached = keycloakSessionCache.get(claims.sessionId);
+			if (cached != null && cached > 0) {
+				Properties context = loadExistingSessionContext(cached);
+				if (context != null) {
+					log.fine("Reusing ADempiere session " + cached
+						+ " populated by parallel thread for sid: " + claims.sessionId);
+					return context;
+				}
+				keycloakSessionCache.remove(claims.sessionId);
 			}
-		}
 
-		// 3. No valid session anywhere — create a new one
-		return createNewSessionContext(claims);
+			// 2. DB fallback: recover session after restart or cache eviction.
+			// Inside the lock so a parallel thread that already inserted the row
+			// is observed instead of duplicated.
+			int dbSessionId = findSessionIdByKeycloakSid(claims.sessionId);
+			if (dbSessionId > 0) {
+				Properties context = loadExistingSessionContext(dbSessionId);
+				if (context != null) {
+					keycloakSessionCache.put(claims.sessionId, dbSessionId); // re-warm cache
+					log.fine("Recovered ADempiere session " + dbSessionId
+						+ " from DB for Keycloak sid: " + claims.sessionId);
+					return context;
+				}
+			}
+
+			// 3. No valid session anywhere — create a new one.
+			return createNewSessionContext(claims);
+		}
 	}
 
 	/**


### PR DESCRIPTION
`KeycloakSessionHandler.resolveSession` had a known race: two concurrent requests carrying the same Keycloak `sid` that both miss the in-memory cache and both miss the DB-fallback lookup would each call `createNewSessionContext`, ending up with **two** `AD_Session` rows tagged `WebSession='keycloak:<sid>'`. Only one would be picked up on subsequent requests (the most recent), but the other(s) would linger as orphans until a deploy or DB cleanup.

This PR adds a per-sid lock around the slow path so concurrent threads observe the same `AD_Session` rather than producing siblings.

## Changes (`KeycloakSessionHandler`)

- New field `private static final ConcurrentMap<String, Object> sidLocks = new ConcurrentHashMap<>();`
- `resolveSession` is restructured into fast path / slow path:
    - **Fast path** (cache hit) stays outside the lock — the common case pays no synchronization cost.
    - **Slow path** runs `synchronized (sidLocks.computeIfAbsent(sid, k -> new Object()))` and **re-checks** both the cache and the DB-fallback **inside** the lock (double-checked locking). The winner does the insert; every loser observes the winner's session and returns it.
- `sidLocks` entries are kept for the JVM lifetime — per-sid memory footprint is negligible and removing entries opens a separate race (thread A still holding lock L1 while thread B creates new lock L2 for the same key).

## Behaviour matrix

| Scenario | Before | After |
|----------|--------|-------|
| Cache hit | One request, one fast lookup | Same — no lock taken | | Single request, cache miss | One DB lookup, one create if needed | Same, inside the per-sid lock | | N concurrent requests, same sid, cache miss | N creates → N orphan `AD_Session` rows | 1 create, N−1 reuse the winner's session |

## Test

1. Smoke: log in via Keycloak normally, hit several endpoints. Expected: no behavioural change in the single-thread case.
2. Concurrency: ```bash # Replace TOKEN with a fresh Keycloak JWT for a new sid (no existing AD_Session). for i in {1..10}; do curl -H "Authorization: Bearer $TOKEN" .../some-endpoint & done wait ``` Then query the DB: ```sql SELECT COUNT(*) FROM AD_Session WHERE WebSession = 'keycloak:<sid>'; ``` Expected: exactly `1`. Before this PR the count was 1–10 depending on timing.

### Additional context
fixes https://github.com/solop-develop/adempiere-solop/issues/1356