### PR TITLE
fix: normalize AD_Language in preferences and add typed PreferenceUtil getters

### DIFF
--- a/src/patches/java/org/compiere/model/MPreference.java
+++ b/src/patches/java/org/compiere/model/MPreference.java
@@ -1,0 +1,176 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 1999-2006 ComPiere, Inc. All Rights Reserved.                *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA        *
+ * or via info@compiere.org or http://www.compiere.org/license.html           *
+ *****************************************************************************/
+package org.compiere.model;
+
+import java.sql.ResultSet;
+import java.util.Properties;
+
+import org.adempiere.core.domains.models.X_AD_Preference;
+import org.compiere.util.DB;
+import org.compiere.util.Util;
+
+/**
+ *	Preference Model
+ *	
+ *  @author Jorg Janke
+ *  @version $Id: MPreference.java,v 1.3 2006/07/30 00:51:03 jjanke Exp $
+ */
+public class MPreference extends X_AD_Preference
+{
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -5098559160325123593L;
+	/**	Null Indicator				*/
+	public static String		NULL = "null";
+	
+	/**
+	 * 	Standatrd Constructor
+	 *	@param ctx ctx
+	 *	@param AD_Preference_ID id
+	 *	@param trxName transaction
+	 */
+	public MPreference(Properties ctx, int AD_Preference_ID, String trxName)
+	{
+		super(ctx, AD_Preference_ID, trxName);
+		if (AD_Preference_ID == 0)
+		{
+		//	setAD_Preference_ID (0);
+		//	setAttribute (null);
+		//	setValue (null);
+		}
+	}	//	MPreference
+
+	/**
+	 * 	Load Contsructor
+	 *	@param ctx context
+	 *	@param rs result set
+	 *	@param trxName transaction
+	 */
+	public MPreference(Properties ctx, ResultSet rs, String trxName)
+	{
+		super(ctx, rs, trxName);
+	}	//	MPreference
+
+	/**
+	 * 	Full Constructor
+	 *	@param ctx context
+	 *	@param Attribute attribute
+	 *	@param Value value
+	 *	@param trxName trx
+	 */
+	public MPreference (Properties ctx, String Attribute, String Value, String trxName)
+	{
+		this (ctx, 0, trxName);
+		setAttribute (Attribute);
+		setValue (Value);
+	}	//	MPreference
+
+	/** Attribute name that stores the user's preferred language. */
+	private static final String ATTRIBUTE_LANGUAGE = "Language";
+
+	/**
+	 * 	Before Save
+	 *	@param newRecord
+	 *	@return true if can be saved
+	 */
+	protected boolean beforeSave (boolean newRecord)
+	{
+		String value = getValue();
+		if (value == null)
+			value = "";
+		if (value.equals("-1"))
+			setValue("");
+		// Defense-in-depth: any preference row holding the user's language
+		// must store a valid AD_Language code (e.g. "es_MX"), never a
+		// localized display name (e.g. "Español (MX)"). Legacy ZK UI
+		// flows persisted the display name directly, which downstream
+		// consumers then forwarded as an identifier — breaking the menu
+		// API, Elasticsearch index resolution, and print engines.
+		if (ATTRIBUTE_LANGUAGE.equals(getAttribute()) && !Util.isEmpty(getValue(), true)) {
+			String normalized = normalizeLanguageCode(getValue());
+			if (!Util.isEmpty(normalized, true)) {
+				setValue(normalized);
+			}
+		}
+		return true;
+	}	//	beforeSave
+
+	/**
+	 * Resolve any language string into a canonical {@code AD_Language}
+	 * code by a tiered lookup against {@code AD_Language}. The input
+	 * length picks the column to match:
+	 * <ol>
+	 *   <li><b>2-char ISO</b> ({@code "es"}, {@code "en"}) → matched
+	 *       against {@code LanguageISO}, returning the system/base
+	 *       AD_Language for that ISO.</li>
+	 *   <li><b>Exact AD_Language code</b> ({@code "es_MX"}, {@code
+	 *       "en_US"}) → matched against {@code AD_Language}.</li>
+	 *   <li><b>Anything else</b> (display names like {@code "Español
+	 *       (MX)"}) → matched against {@code Name} or {@code PrintName}.</li>
+	 * </ol>
+	 * Returns null when no tier produces a match — the caller leaves the
+	 * raw value in place so legacy data is not destroyed.
+	 */
+	public static String normalizeLanguageCode(String input) {
+		if (Util.isEmpty(input, true)) {
+			return null;
+		}
+		String trimmed = input.trim();
+		if (trimmed.length() == 2) {
+			return DB.getSQLValueString(
+				null,
+				"SELECT AD_Language FROM AD_Language "
+					+ "WHERE UPPER(LanguageISO) = UPPER(?) "
+					+ "AND (IsSystemLanguage = 'Y' OR IsBaseLanguage = 'Y') "
+					+ "AND ROWNUM = 1",
+				trimmed
+			);
+		}
+		String code = DB.getSQLValueString(
+			null,
+			"SELECT AD_Language FROM AD_Language "
+				+ "WHERE UPPER(AD_Language) = UPPER(?) "
+				+ "AND ROWNUM = 1",
+			trimmed
+		);
+		if (!Util.isEmpty(code, true)) {
+			return code;
+		}
+		return DB.getSQLValueString(
+			null,
+			"SELECT AD_Language FROM AD_Language "
+				+ "WHERE (UPPER(Name) = UPPER(?) OR UPPER(PrintName) = UPPER(?)) "
+				+ "AND ROWNUM = 1",
+			trimmed, trimmed
+		);
+	}
+
+	/**
+	 * 	String Representation
+	 *	@return info
+	 */
+	public String toString ()
+	{
+		StringBuffer sb = new StringBuffer ("MPreference[");
+		sb.append (get_ID()).append("-")
+			.append(getAttribute()).append("-").append(getValue())
+			.append ("]");
+		return sb.toString ();
+	}	//	toString
+	
+}	//	MPreference

--- a/src/patches/java/org/spin/service/grpc/authentication/KeycloakSessionHandler.java
+++ b/src/patches/java/org/spin/service/grpc/authentication/KeycloakSessionHandler.java
@@ -1,0 +1,385 @@
+package org.spin.service.grpc.authentication;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.adempiere.exceptions.AdempiereException;
+import org.compiere.model.MRole;
+import org.compiere.model.MSession;
+import org.compiere.util.CCache;
+import org.compiere.util.CLogger;
+import org.compiere.util.DB;
+import org.compiere.util.Env;
+import org.compiere.util.Util;
+import org.spin.service.grpc.util.base.PreferenceUtil;
+
+import java.sql.Timestamp;
+import java.util.Base64;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Resolves an ADempiere session from a pre-validated Keycloak JWT.
+ * <p>
+ * The JWT was already validated by nginx + OAuth2 Proxy, so this handler
+ * only decodes the payload (Base64) to extract claims, then maps the
+ * Keycloak identity to an existing ADempiere user.
+ * <p>
+ * Sessions are cached by Keycloak session ID (sid) to avoid creating
+ * a new ADempiere session on every request.
+ * <p>
+ * This is the gRPC equivalent of {@code com.sabana.auth.services.KeycloakSessionService}
+ * but without Spring dependencies — all static methods, plain Java.
+ */
+public class KeycloakSessionHandler {
+
+	private static final CLogger log = CLogger.getCLogger(KeycloakSessionHandler.class);
+
+	/** Cache: Keycloak sid -> ADempiere AD_Session_ID.
+	 *  Name must NOT start with "AD_Session" to avoid being wiped
+	 *  by CacheMgt.reset("AD_Session") on every MSession save. */
+	private static final CCache<String, Integer> keycloakSessionCache =
+		new CCache<>("KeycloakSidMapping", 100, 60); // 60 min timeout
+
+	/**
+	 * Per-sid lock used to serialize the slow path (DB-fallback + create) so that
+	 * two concurrent requests for the same Keycloak sid do not both miss cache,
+	 * both miss DB, and each insert a brand-new AD_Session with the same
+	 * {@code WebSession="keycloak:<sid>"}. Entries are kept for the lifetime of
+	 * the JVM — the per-sid memory footprint is negligible.
+	 */
+	private static final ConcurrentMap<String, Object> sidLocks = new ConcurrentHashMap<>();
+
+	/**
+	 * Resolves an ADempiere session context from a Keycloak JWT.
+	 * <p>
+	 * 1. Decode JWT payload (Base64, no signature validation)
+	 * 2. Extract email, preferred_username, and sid (Keycloak session ID)
+	 * 3. Check if an ADempiere session already exists for this Keycloak sid
+	 * 4. If yes, reload the existing session context
+	 * 5. If no, find AD_User, resolve defaults, create new MSession
+	 * 6. Build full context with preferences and defaults
+	 *
+	 * @param token JWT string without "Bearer " prefix
+	 * @return Properties context with session data
+	 */
+	public static Properties resolveSession(String token) {
+		KeycloakClaims claims = decodeClaims(token);
+		log.fine("Keycloak claims — sub: " + claims.sub + ", email: " + claims.email
+			+ ", username: " + claims.preferredUsername + ", sid: " + claims.sessionId);
+
+		if (claims.sessionId == null || claims.sessionId.isBlank()) {
+			throw new AdempiereException("Keycloak JWT missing 'sid' claim");
+		}
+
+		// 1. Fast path: in-memory cache (no lock — cache reads are thread-safe).
+		Integer existingSessionId = keycloakSessionCache.get(claims.sessionId);
+		if (existingSessionId != null && existingSessionId > 0) {
+			Properties context = loadExistingSessionContext(existingSessionId);
+			if (context != null) {
+				log.fine("Reusing cached ADempiere session " + existingSessionId
+					+ " for Keycloak sid: " + claims.sessionId);
+				return context;
+			}
+			keycloakSessionCache.remove(claims.sessionId);
+		}
+
+		// Slow path: serialize per-sid so two concurrent requests that both
+		// miss the cache do not both reach createNewSessionContext and produce
+		// duplicate AD_Session rows for the same Keycloak sid.
+		Object lock = sidLocks.computeIfAbsent(claims.sessionId, k -> new Object());
+		synchronized (lock) {
+			// Re-check the cache: a parallel thread that won the race may have
+			// already populated it while we waited.
+			Integer cached = keycloakSessionCache.get(claims.sessionId);
+			if (cached != null && cached > 0) {
+				Properties context = loadExistingSessionContext(cached);
+				if (context != null) {
+					log.fine("Reusing ADempiere session " + cached
+						+ " populated by parallel thread for sid: " + claims.sessionId);
+					return context;
+				}
+				keycloakSessionCache.remove(claims.sessionId);
+			}
+
+			// 2. DB fallback: recover session after restart or cache eviction.
+			// Inside the lock so a parallel thread that already inserted the row
+			// is observed instead of duplicated.
+			int dbSessionId = findSessionIdByKeycloakSid(claims.sessionId);
+			if (dbSessionId > 0) {
+				Properties context = loadExistingSessionContext(dbSessionId);
+				if (context != null) {
+					keycloakSessionCache.put(claims.sessionId, dbSessionId); // re-warm cache
+					log.fine("Recovered ADempiere session " + dbSessionId
+						+ " from DB for Keycloak sid: " + claims.sessionId);
+					return context;
+				}
+			}
+
+			// 3. No valid session anywhere — create a new one.
+			return createNewSessionContext(claims);
+		}
+	}
+
+	/**
+	 * Load context from an existing ADempiere session.
+	 * Returns null if the session is no longer valid.
+	 */
+	private static Properties loadExistingSessionContext(int sessionId) {
+		MSession session = new MSession(Env.getCtx(), sessionId, null);
+		if (session.getAD_Session_ID() <= 0 || session.isProcessed()) {
+			return null;
+		}
+
+		// The Keycloak flow tags AD_Session.WebSession with "keycloak:<sid>" so the
+		// DB-fallback lookup can find it. A reused AD_Session_ID with a different
+		// tag means another flow created the row — likely the sid-cache mapping
+		// got corrupted and we are about to load the wrong user's session.
+		String webSession = session.getWebSession();
+		if (webSession == null || !webSession.startsWith("keycloak:")) {
+			log.warning("Keycloak session resolve loaded AD_Session_ID=" + sessionId
+				+ " with unexpected WebSession='" + webSession + "' — refusing reuse");
+			return null;
+		}
+
+		Properties context = (Properties) Env.getCtx().clone();
+		DB.validateSupportedUUIDFromDB();
+
+		// Set context from existing session
+		Env.setContext(context, "#AD_Session_ID", session.getAD_Session_ID());
+		Env.setContext(context, "#Session_UUID", session.getUUID());
+		Env.setContext(context, "#AD_User_ID", session.getCreatedBy());
+		Env.setContext(context, "#AD_Role_ID", session.getAD_Role_ID());
+		Env.setContext(context, "#AD_Client_ID", session.getAD_Client_ID());
+		Env.setContext(context, "#AD_Org_ID", session.getAD_Org_ID());
+		Env.setContext(context, "#Date", new Timestamp(System.currentTimeMillis()));
+
+		// Force-reload the role so its cached access SQL is rebuilt with the
+		// current tenant context — protects against role instances cached with
+		// a stale #AD_Client_ID (e.g. left over from a System → Company switch).
+		MRole.removeFromCache(session.getAD_Role_ID(), session.getCreatedBy());
+		MRole.get(context, session.getAD_Role_ID(), session.getCreatedBy(), true);
+
+		int orgId = session.getAD_Org_ID();
+
+		// Load language and warehouse from saved preferences (written by setSessionAttribute / runChangeRole)
+		// Cannot rely on session.getCtx() because MSession has no AD_Language column —
+		// getCtx() returns the global context, not the session-specific one.
+		// getLanguagePreference normalises legacy display-name values like
+		// "Español (MX)" (left in AD_Preference by the ZK UI login flow) back
+		// into a real AD_Language code such as "es_MX", so the downstream
+		// services receive a code that they can use as a query parameter.
+		int userId = session.getCreatedBy();
+		String language = PreferenceUtil.getLanguagePreference(userId);
+		int warehouseId = PreferenceUtil.getWarehousePreference(userId);
+		if (Util.isEmpty(language, true)) {
+			language = SessionManager.getDefaultLanguage(null);
+		}
+		if (warehouseId < 0) {
+			warehouseId = SessionManager.getDefaultWarehouseId(orgId);
+		}
+		if (warehouseId < 0) {
+			warehouseId = 0;
+		}
+		Env.setContext(context, "#M_Warehouse_ID", warehouseId);
+		// Load preferences and defaults
+		SessionManager.loadDefaultSessionValues(context, language);
+
+		return context;
+	}
+
+	/**
+	 * Query AD_Session by WebSession column for DB-backed recovery after server restart.
+	 * Returns the most recently created valid session ID, or -1 if not found.
+	 */
+	private static int findSessionIdByKeycloakSid(String keycloakSid) {
+		int result = DB.getSQLValue(
+			null,
+			"SELECT AD_Session_ID FROM AD_Session "
+				+ "WHERE WebSession = ? AND Processed = 'N' "
+				+ "ORDER BY Created DESC LIMIT 1",
+			"keycloak:" + keycloakSid
+		);
+		return result > 0 ? result : -1;
+	}
+
+	/**
+	 * Create a new ADempiere session for a Keycloak user.
+	 * Maps Keycloak identity to AD_User, resolves defaults, and creates MSession
+	 * with the Keycloak sid stored in WebSession for traceability.
+	 */
+	private static Properties createNewSessionContext(KeycloakClaims claims) {
+		int userId = findAdempiereUserId(claims);
+
+		int roleId = SessionManager.getDefaultRoleId(userId);
+		if (roleId < 0) {
+			throw new AdempiereException(
+				"@AD_Role_ID@ @NotFound@ for Keycloak user: " + claims.email);
+		}
+
+		int orgId = SessionManager.getDefaultOrganizationId(roleId, userId);
+		if (orgId < 0) {
+			orgId = 0;
+		}
+
+		// Read previously-saved language/warehouse preferences for the user so
+		// a new Keycloak session does not silently fall back to the client/
+		// system default. Mirrors loadExistingSessionContext so the same user
+		// gets the same language whether the session is created or recovered.
+		String language = PreferenceUtil.getLanguagePreference(userId);
+		int warehouseId = PreferenceUtil.getWarehousePreference(userId);
+		if (Util.isEmpty(language, true)) {
+			language = SessionManager.getDefaultLanguage(null);
+		}
+		if (warehouseId < 0) {
+			warehouseId = SessionManager.getDefaultWarehouseId(orgId);
+		}
+		if (warehouseId < 0) {
+			warehouseId = 0;
+		}
+
+		// Create session using SessionManager
+		MSession session = SessionManager.createSession(
+			"grpc-keycloak",
+			language,
+			roleId,
+			userId,
+			orgId,
+			warehouseId
+		);
+
+		// Store Keycloak sid in WebSession for traceability
+		session.setWebSession("keycloak:" + claims.sessionId);
+		session.saveEx();
+
+		// Cache the mapping: Keycloak sid -> ADempiere session ID
+		keycloakSessionCache.put(claims.sessionId, session.getAD_Session_ID());
+
+		// Build context following getSessionFromToken pattern
+		Properties context = session.getCtx();
+		Env.setContext(context, "#AD_Session_ID", session.getAD_Session_ID());
+		Env.setContext(context, "#Session_UUID", session.getUUID());
+		Env.setContext(context, "#AD_User_ID", session.getCreatedBy());
+		Env.setContext(context, "#AD_Role_ID", session.getAD_Role_ID());
+		Env.setContext(context, "#AD_Client_ID", session.getAD_Client_ID());
+		Env.setContext(context, "#AD_Org_ID", orgId);
+		Env.setContext(context, "#M_Warehouse_ID", warehouseId);
+		Env.setContext(context, "#Date", new Timestamp(System.currentTimeMillis()));
+		Env.setContext(context, Env.LANGUAGE, SessionManager.getDefaultLanguage(language));
+
+		// Load preferences and defaults
+		SessionManager.loadDefaultSessionValues(context, language);
+
+		log.info("Created new ADempiere session " + session.getAD_Session_ID()
+			+ " for Keycloak sid: " + claims.sessionId
+			+ ", user: " + claims.email + " (AD_User_ID=" + userId + ")");
+
+		return context;
+	}
+
+	/**
+	 * Decode JWT payload (Base64, no signature validation) and extract Keycloak claims.
+	 */
+	private static KeycloakClaims decodeClaims(String token) {
+		try {
+			String[] parts = token.split("\\.");
+			if (parts.length != 3) {
+				throw new AdempiereException("Invalid JWT structure");
+			}
+			String payload = new String(Base64.getUrlDecoder().decode(parts[1]));
+			JsonObject node = JsonParser.parseString(payload).getAsJsonObject();
+			return new KeycloakClaims(
+				getTextOrNull(node, "sub"),
+				getTextOrNull(node, "email"),
+				getTextOrNull(node, "preferred_username"),
+				getTextOrNull(node, "name"),
+				getTextOrNull(node, "sid")
+			);
+		} catch (AdempiereException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new AdempiereException("Failed to decode Keycloak JWT: " + e.getMessage());
+		}
+	}
+
+	private static String getTextOrNull(JsonObject node, String field) {
+		return node.has(field) && !node.get(field).isJsonNull()
+			? node.get(field).getAsString()
+			: null;
+	}
+
+	/**
+	 * Find ADempiere user matching Keycloak identity.
+	 * Priority: email > username (preferred_username).
+	 */
+	private static int findAdempiereUserId(KeycloakClaims claims) {
+		// Priority 1: find by email (case-insensitive)
+		if (!Util.isEmpty(claims.email, true)) {
+			int userId = DB.getSQLValue(
+				null,
+				"SELECT AD_User_ID FROM AD_User WHERE LOWER(EMail) = LOWER(?) AND IsActive = 'Y' LIMIT 1",
+				claims.email
+			);
+			if (userId > 0) {
+				return userId;
+			}
+		}
+		// Priority 2: find by username (Value column in AD_User, case-insensitive)
+		if (!Util.isEmpty(claims.preferredUsername, true)) {
+			int userId = DB.getSQLValue(
+				null,
+				"SELECT AD_User_ID FROM AD_User WHERE LOWER(Value) = LOWER(?) AND IsActive = 'Y' LIMIT 1",
+				claims.preferredUsername
+			);
+			if (userId > 0) {
+				return userId;
+			}
+		}
+		throw new AdempiereException(
+			"ADempiere user not found for Keycloak identity — email: "
+				+ claims.email + ", username: " + claims.preferredUsername);
+	}
+
+	/**
+	 * Updates the Keycloak sid -> AD_Session_ID cache mapping.
+	 * Called after change-role creates a new ADempiere session.
+	 */
+	public static void updateSessionCache(String keycloakSid, int newSessionId) {
+		if (keycloakSid == null || keycloakSid.isBlank() || newSessionId <= 0) {
+			return;
+		}
+		keycloakSessionCache.put(keycloakSid, newSessionId);
+		log.fine("Updated Keycloak session cache — sid: " + keycloakSid
+			+ " → AD_Session_ID: " + newSessionId);
+	}
+
+	/**
+	 * Extracts the Keycloak session ID (sid) from a JWT token.
+	 * Returns null if the token is not a valid Keycloak JWT or has no sid.
+	 */
+	public static String extractSessionId(String token) {
+		try {
+			KeycloakClaims claims = decodeClaims(token);
+			return claims.sessionId;
+		} catch (Exception e) {
+			return null;
+		}
+	}
+
+	/** Keycloak JWT claims */
+	private static class KeycloakClaims {
+		final String sub;
+		final String email;
+		final String preferredUsername;
+		final String name;
+		final String sessionId;
+
+		KeycloakClaims(String sub, String email, String preferredUsername, String name, String sessionId) {
+			this.sub = sub;
+			this.email = email;
+			this.preferredUsername = preferredUsername;
+			this.name = name;
+			this.sessionId = sessionId;
+		}
+	}
+}

--- a/src/patches/java/org/spin/service/grpc/util/base/PreferenceUtil.java
+++ b/src/patches/java/org/spin/service/grpc/util/base/PreferenceUtil.java
@@ -1,0 +1,278 @@
+/************************************************************************************
+ * Copyright (C) 2018-present E.R.P. Consultores y Asociados, C.A.                  *
+ * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com                     *
+ * This program is free software: you can redistribute it and/or modify             *
+ * it under the terms of the GNU General Public License as published by             *
+ * the Free Software Foundation, either version 2 of the License, or                *
+ * (at your option) any later version.                                              *
+ * This program is distributed in the hope that it will be useful,                  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
+ * GNU General Public License for more details.                                     *
+ * You should have received a copy of the GNU General Public License                *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.            *
+ ************************************************************************************/
+package org.spin.service.grpc.util.base;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.adempiere.core.domains.models.I_AD_Preference;
+import org.compiere.model.MPreference;
+import org.compiere.model.Query;
+import org.compiere.util.Env;
+import org.compiere.util.Util;
+
+public class PreferenceUtil {
+	/** Language			*/
+	public static final String P_LANGUAGE = "Language";
+
+	/** Role */
+	public static final String P_ROLE = "Role";
+
+	/** Client Name */
+	public static final String P_CLIENT = "Client";
+
+	/** Org Name */
+	public static final String P_ORG = "Organization";
+
+	/** Warehouse Name */
+	public static final String P_WAREHOUSE = "Warehouse";
+
+
+	public static List<String> PROPERTIES_LIST = Arrays.asList(
+		P_LANGUAGE, P_ROLE, P_CLIENT, P_ORG, P_WAREHOUSE
+	);
+
+
+	/**
+	 * Get Session Preferences
+	 * @param userId
+	 * @return
+	 */
+	public static List<MPreference> getSessionPreferences(int userId) {
+		List<MPreference> preferencesList = new ArrayList<MPreference>();
+		if (userId <= 0) {
+			return preferencesList;
+		}
+
+		ArrayList<Object> queryParameters = new ArrayList<>();
+		queryParameters.add(userId);
+		queryParameters.addAll(PreferenceUtil.PROPERTIES_LIST);
+
+		preferencesList = new Query(
+			Env.getCtx(),
+			I_AD_Preference.Table_Name,
+			"AD_User_ID = ? AND Attribute IN(?, ?, ?, ?, ?) AND AD_Window_ID Is NULL",
+			null
+		)
+			.setOrderBy(I_AD_Preference.COLUMNNAME_Created + " DESC")
+			.setParameters(queryParameters)
+			.<MPreference>list()
+		;
+		return preferencesList;
+	}
+
+
+	/**
+	 * Get the most recent value of a single preference for a user.
+	 * Returns null if the preference is not set or invalid input.
+	 *
+	 * @param userId AD_User_ID owner of the preference
+	 * @param attributeName one of the P_* constants in this class
+	 * @return raw string value of the preference, or null
+	 */
+	public static String getPreferenceValue(int userId, String attributeName) {
+		if (userId <= 0 || Util.isEmpty(attributeName, true)) {
+			return null;
+		}
+		MPreference preference = new Query(
+			Env.getCtx(),
+			I_AD_Preference.Table_Name,
+			"AD_User_ID = ? AND Attribute = ? AND AD_Window_ID Is NULL",
+			null
+		)
+			.setOrderBy(I_AD_Preference.COLUMNNAME_Created + " DESC")
+			.setParameters(userId, attributeName)
+			.<MPreference>first()
+		;
+		if (preference == null) {
+			return null;
+		}
+		return preference.getValue();
+	}
+
+
+	/**
+	 * Parse a preference value into a positive AD_*_ID, or return -1 when the
+	 * value is missing or non-numeric. Callers use the -1 sentinel to fall back
+	 * to a system default and to avoid trusting unparseable preference data.
+	 */
+	private static int parseIdOrNegative(String value) {
+		if (Util.isEmpty(value, true)) {
+			return -1;
+		}
+		try {
+			return Integer.parseInt(value);
+		} catch (NumberFormatException e) {
+			return -1;
+		}
+	}
+
+
+	/**
+	 * Get the user's preferred language as a valid {@code AD_Language} code
+	 * (e.g. {@code es_VE}). Returns null when the preference is missing,
+	 * blank, or when the stored value does not normalise to any row in
+	 * {@code AD_Language} — this last case protects against legacy data
+	 * where the human-readable name (e.g. "Español (MX)") was saved into
+	 * {@code AD_Preference.Value} instead of the language code, which
+	 * downstream services then forward as a query parameter and break.
+	 *
+	 * 2-char ISO codes (e.g. {@code "es"}, {@code "en"}) are accepted and
+	 * resolved to the matching system/base AD_Language.
+	 */
+	public static String getLanguagePreference(int userId) {
+		return normalizeLanguageCode(
+			getPreferenceValue(userId, P_LANGUAGE)
+		);
+	}
+
+
+	/**
+	 * Thin wrapper around {@link MPreference#normalizeLanguageCode(String)}
+	 * so the tiered lookup against {@code AD_Language} lives in a single
+	 * place. Returns the canonical {@code AD_Language} code, or null when
+	 * the input does not match any row.
+	 */
+	private static String normalizeLanguageCode(String input) {
+		return MPreference.normalizeLanguageCode(input);
+	}
+
+
+	/**
+	 * Get the user's preferred AD_Role_ID, or -1 if no preference is set.
+	 * Callers MUST validate that the user still has access to this role
+	 * before using it (privilege-escalation defense).
+	 */
+	public static int getRolePreference(int userId) {
+		return parseIdOrNegative(
+			getPreferenceValue(userId, P_ROLE)
+		);
+	}
+
+
+	/**
+	 * Get the user's preferred AD_Client_ID, or -1 if no preference is set.
+	 * Normally derived from the preferred role; kept for traceability.
+	 */
+	public static int getClientPreference(int userId) {
+		return parseIdOrNegative(
+			getPreferenceValue(userId, P_CLIENT)
+		);
+	}
+
+
+	/**
+	 * Get the user's preferred AD_Org_ID, or -1 if no preference is set.
+	 * Callers MUST validate that the (user, role) combination still has
+	 * access to this organization (privilege-escalation defense).
+	 */
+	public static int getOrganizationPreference(int userId) {
+		return parseIdOrNegative(
+			getPreferenceValue(userId, P_ORG)
+		);
+	}
+
+
+	/**
+	 * Get the user's preferred M_Warehouse_ID, or -1 if no preference is set.
+	 */
+	public static int getWarehousePreference(int userId) {
+		return parseIdOrNegative(
+			getPreferenceValue(userId, P_WAREHOUSE)
+		);
+	}
+
+
+	/**
+	 * Save Session Preferences
+	 * @param userId
+	 * @param language
+	 * @param roleId
+	 * @param clientId
+	 * @param organizationId
+	 * @param warehouseId
+	 */
+	public static void saveSessionPreferences(
+		// query
+		int userId,
+		// values
+		String language, int roleId, int clientId, int organizationId, int warehouseId
+	) {
+		if (userId <= 0) {
+			return;
+		}
+
+		Query query = new Query(
+			Env.getCtx(),
+			I_AD_Preference.Table_Name,
+			"AD_User_ID = ? AND Attribute = ? AND AD_Window_ID Is NULL",
+			null
+		)
+			.setOrderBy(I_AD_Preference.COLUMNNAME_Created + " DESC")
+		;
+
+		for (String attributeName : PROPERTIES_LIST) {
+			if (Util.isEmpty(attributeName, true)) {
+				// next iteration
+				continue;
+			}
+			MPreference preference = query
+				.setParameters(userId, attributeName)
+				.first()
+			;
+			if (preference == null) {
+				preference = new MPreference(Env.getCtx(), 0, null);
+				preference.setAD_User_ID(userId);
+				preference.setAttribute(attributeName);
+			} 
+			if (preference.getAD_Client_ID() > 0 || preference.getAD_Org_ID() > 0) {
+				preference.set_ValueOfColumn(I_AD_Preference.COLUMNNAME_AD_Client_ID, 0);
+				preference.set_ValueOfColumn(I_AD_Preference.COLUMNNAME_AD_Org_ID, 0);
+			}
+			// set values
+			if (attributeName.equals(PreferenceUtil.P_ROLE)) {
+				preference.setValue(
+					String.valueOf(roleId)
+				);
+			} else if (attributeName.equals(PreferenceUtil.P_CLIENT)) {
+				preference.setValue(
+					String.valueOf(clientId)
+				);
+			} else if (attributeName.equals(PreferenceUtil.P_ORG)) {
+				preference.setValue(
+					String.valueOf(organizationId)
+				);
+			} else if (attributeName.equals(PreferenceUtil.P_WAREHOUSE)) {
+				preference.setValue(
+					String.valueOf(warehouseId)
+				);
+			} else if (attributeName.equals(PreferenceUtil.P_LANGUAGE)) {
+				String normalized = normalizeLanguageCode(language);
+				if (Util.isEmpty(normalized, true)) {
+					// Caller passed a value that is not a recognised
+					// AD_Language code (typically the human-readable
+					// display name like "Español (MX)"). Skip the save so
+					// we do not overwrite the existing row with junk —
+					// the next login falls back to the system default.
+					continue;
+				}
+				preference.setValue(normalized);
+			}
+			preference.save();
+		}
+	}
+
+}


### PR DESCRIPTION

## Summary
- `MPreference.beforeSave` now normalizes the `Language` attribute to a valid `AD_Language` code at storage time, regardless of which caller wrote the row.
- A new public `MPreference.normalizeLanguageCode(String)` exposes a tiered lookup (2-char ISO → `LanguageISO`, full code → `AD_Language`, anything else → `Name`/`PrintName`) as the single source of truth for resolving any language string into a canonical code.
- `PreferenceUtil` gains typed, validated getters (`getLanguagePreference`, `getRolePreference`, `getClientPreference`, `getOrganizationPreference`, `getWarehousePreference`) and delegates its internal normalization to `MPreference.normalizeLanguageCode`, eliminating the duplicated SQL.
- `PreferenceUtil.saveSessionPreferences` skips the language write when the supplied value does not normalize, so a junk caller cannot overwrite a previously good row.

## Root cause
Legacy UI flows (most visibly the ZK UI login/role flow) persisted the localized display name returned by `Language.getName()` — e.g. `"Español (MX)"` — into `AD_Preference.Value` for the `Language` attribute. Downstream consumers that read the preference as an identifier (gRPC `session-info`, the Vue/Tepuy menu API, Elasticsearch index resolution, print engines) then forwarded that value as a query parameter, breaking with HTTP 500 when no index/locale could be resolved from a display name. With multiple callers writing to `AD_Preference` across the platform, a single point of normalization at the model layer is needed so the data shape is invariant to the writer.

## Changes
### `org/compiere/model/MPreference.java`
- New constant `ATTRIBUTE_LANGUAGE = "Language"` used by `beforeSave`.
- `beforeSave` now invokes the new `normalizeLanguageCode` for rows whose `Attribute` is `Language`, replacing the stored value with the canonical `AD_Language` code when a match is found. When no row matches, the raw value is left in place so existing data is not destroyed.
- New `public static String normalizeLanguageCode(String input)` — tiered SQL lookup against `AD_Language`, returns `null` when the input does not resolve.
- New imports: `org.compiere.util.DB`, `org.compiere.util.Util`.

### `org/spin/service/grpc/util/base/PreferenceUtil.java`
- New `getPreferenceValue(int userId, String attributeName)` — fetches the most recent value of one preference for a user.
- New `parseIdOrNegative(String value)` — parses an `AD_*_ID` from preference text, returning `-1` for missing/non-numeric values so callers can fall back to a system default and never trust unparseable data.
- New typed getters: `getLanguagePreference`, `getRolePreference`, `getClientPreference`, `getOrganizationPreference`, `getWarehousePreference`. These collapse the previous loop-and-switch retrieval pattern at call sites and document the validation expectations (role/org callers MUST re-check access — privilege-escalation defense).
- `saveSessionPreferences`: for the `Language` row, the new value is normalized via the shared `MPreference` helper before being written; when normalization returns `null` (the caller passed a display name or unknown string) the iteration `continue`s, leaving the existing row untouched.
- Internal `normalizeLanguageCode` is reduced to a thin wrapper that delegates to `MPreference.normalizeLanguageCode`, so the SQL lives in one place.
- Removed unused `org.compiere.util.DB` import.

## Compatibility
- Existing rows in `AD_Preference` are not migrated. They auto-heal on the next `save()` cycle thanks to `MPreference.beforeSave`, and the read path (`PreferenceUtil.getLanguagePreference`) tolerates the legacy display-name format during the transition.
- No public API was removed. `getSessionPreferences` and `saveSessionPreferences` keep their existing signatures; the new typed getters are additive.
- No DDL changes; the new SQL is read-only and uses `ROWNUM = 1` for cross-DB compatibility.

## Test plan
- [ ] On a database where `AD_Preference` contains rows with a display-name value for `Attribute = 'Language'` (e.g. `Español (MX)`), trigger any update of that row (role switch, login flow that saves preferences) and verify the value is rewritten to the matching `AD_Language` code (`es_MX`).
- [ ] Insert a fresh `AD_Preference` row programmatically with the language attribute set to a 2-char ISO (`es`), save, and confirm `Value` is stored as the canonical AD_Language code.
- [ ] Insert with an unknown string (e.g. `xyz`), save, and confirm the value is left in place (no exception, no overwrite to `null`).
- [ ] Call `PreferenceUtil.getLanguagePreference` on a row known to hold a legacy display name and confirm it returns the canonical code.
- [ ] Call `PreferenceUtil.saveSessionPreferences` with `language = "Español (MX)"` for a user who already has a valid stored language; confirm the stored value is NOT overwritten (skip-on-junk guarantee).
- [ ] Build downstream services that consume `adempiere-core` (e.g. the gRPC server and report-engine) against this version and confirm no compilation regressions.

### Additional context
fixes https://github.com/solop-develop/adempiere-solop/issues/2948